### PR TITLE
Fix Camera Ginkgo

### DIFF
--- a/services/camera/libcameraservice/CameraService.cpp
+++ b/services/camera/libcameraservice/CameraService.cpp
@@ -37,6 +37,7 @@
 
 #include <android-base/macros.h>
 #include <android-base/parseint.h>
+#include <android-base/properties.h>
 #include <android-base/stringprintf.h>
 #include <binder/ActivityManager.h>
 #include <binder/AppOpsManager.h>
@@ -88,6 +89,7 @@ namespace {
 namespace android {
 
 using base::StringPrintf;
+using base::SetProperty;
 using binder::Status;
 using frameworks::cameraservice::service::V2_0::implementation::HidlCameraService;
 using hardware::ICamera;
@@ -2982,6 +2984,15 @@ status_t CameraService::BasicClient::startCameraOps() {
     }
 
     mOpsActive = true;
+
+    // Configure miui camera mode
+    if (strcmp(String8(mClientPackageName).string(), "com.android.camera") == 0) {
+        SetProperty("sys.camera.miui.apk", "1");
+        ALOGI("Enabling miui camera mode");
+    } else {
+        SetProperty("sys.camera.miui.apk", "0");
+        ALOGI("Disabling miui camera mode");
+    }
 
     // Transition device availability listeners from PRESENT -> NOT_AVAILABLE
     sCameraService->updateStatus(StatusInternal::NOT_AVAILABLE, mCameraIdStr);


### PR DESCRIPTION
 * devices like ginkgo and some xiaomi sdm660 use miui camera mode in camera
   hal to activate certain functions in camera hal, there are activated when
   vendor.camera.miui.apk is set to 1 (which we do in init.target.rc relaying
   value of sys.camera.miui.apk). if this prop is set by default gcam crashes
   so we must do it dynamically. xiaomi did the same way in stock libcameraservice
   but unforunately we don't have stock a11 so replicating it in OSS libcam

This is needed for ginkgo

Signed-off-by: Joey Huab <joey@evolution-x.org>